### PR TITLE
Remove deprecated command

### DIFF
--- a/Formula/startship.rb
+++ b/Formula/startship.rb
@@ -5,8 +5,6 @@ class Startship < Formula
   version "1.1.1"
   sha256 "be4cd615ee5f4c0792ffea45baed2a7894fd79c5b4b91b05a1c895b4ef27359d"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   def install


### PR DESCRIPTION
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the saket/repo tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/saket/homebrew-repo/Formula/startship.rb:8
```